### PR TITLE
Feature/recent posts infinite scroll

### DIFF
--- a/app/src/main/java/com/cesar/androidtest/recentposts/RecentPostsActivity.kt
+++ b/app/src/main/java/com/cesar/androidtest/recentposts/RecentPostsActivity.kt
@@ -61,14 +61,18 @@ open class RecentPostsActivity : AppCompatActivity(), RecentPostsContract.View,
 
         scrollListener = object : EndlessRecyclerViewScrollListener(linearLayoutManager) {
             override fun onLoadMore(page: Int, totalItemsCount: Int, view: RecyclerView?) {
-                loadNextDataFromApi(page)
+                loadNextDataFromApi()
             }
         }
         recyclerView.addOnScrollListener(scrollListener)
     }
 
-    fun loadNextDataFromApi(page: Int) {
-        presenter.requestMoreItems()
+    fun loadNextDataFromApi() {
+        var lastName: String? = null
+        if (!postsList.isEmpty()) {
+            lastName = postsList.last().data?.name
+        }
+        presenter.requestMoreItems(lastName)
         // TODO: Append the new data objects to the existing set of items inside the array of items
         // TODO: Notify the adapter of the new items made with `notifyItemRangeInserted()`
     }

--- a/app/src/main/java/com/cesar/androidtest/recentposts/RecentPostsActivity.kt
+++ b/app/src/main/java/com/cesar/androidtest/recentposts/RecentPostsActivity.kt
@@ -92,6 +92,12 @@ open class RecentPostsActivity : AppCompatActivity(), RecentPostsContract.View,
             adapter.notifyDataSetChanged()
         }
     }
+    override fun onListAddingComplete(response: List<RecentPostModel>) {
+        runOnUiThread {
+            postsList.addAll(response)
+            adapter.notifyDataSetChanged()
+        }
+    }
 
     override fun onPostsListItemClicked(listItem: View) {
         presenter.onPostsListItemClicked()

--- a/app/src/main/java/com/cesar/androidtest/recentposts/RecentPostsActivity.kt
+++ b/app/src/main/java/com/cesar/androidtest/recentposts/RecentPostsActivity.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import android.support.v4.widget.SwipeRefreshLayout
 import android.support.v7.app.AppCompatActivity
 import android.support.v7.widget.LinearLayoutManager
+import android.support.v7.widget.RecyclerView
 import android.util.Log
 import android.view.View
 import com.cesar.androidtest.R
@@ -11,6 +12,7 @@ import com.cesar.androidtest.httpclient.retrofit.di.DaggerNetworkComponent
 import com.cesar.androidtest.recentposts.di.DaggerRecentPostsComponent
 import com.cesar.androidtest.recentposts.di.RecentPostsModule
 import com.cesar.androidtest.recentposts.model.RecentPostModel
+import com.cesar.androidtest.recentposts.recyclerview.EndlessRecyclerViewScrollListener
 import com.cesar.androidtest.recentposts.recyclerview.RecyclerAdapter
 import com.squareup.picasso.Picasso
 import kotlinx.android.synthetic.main.activity_recentposts.*
@@ -27,6 +29,7 @@ open class RecentPostsActivity : AppCompatActivity(), RecentPostsContract.View,
     private lateinit var adapter: RecyclerAdapter
     private lateinit var linearLayoutManager: LinearLayoutManager
     private var postsList: ArrayList<RecentPostModel> = ArrayList()
+    private lateinit var scrollListener: EndlessRecyclerViewScrollListener
 
     open fun initializeDependencies() {
         DaggerRecentPostsComponent.builder()
@@ -55,6 +58,19 @@ open class RecentPostsActivity : AppCompatActivity(), RecentPostsContract.View,
 
         adapter = RecyclerAdapter(this, postsList, picasso)
         recyclerView.adapter = adapter
+
+        scrollListener = object : EndlessRecyclerViewScrollListener(linearLayoutManager) {
+            override fun onLoadMore(page: Int, totalItemsCount: Int, view: RecyclerView?) {
+                loadNextDataFromApi(page)
+            }
+        }
+        recyclerView.addOnScrollListener(scrollListener)
+    }
+
+    fun loadNextDataFromApi(page: Int) {
+        presenter.requestMoreItems()
+        // TODO: Append the new data objects to the existing set of items inside the array of items
+        // TODO: Notify the adapter of the new items made with `notifyItemRangeInserted()`
     }
 
     override fun onRefresh() {

--- a/app/src/main/java/com/cesar/androidtest/recentposts/RecentPostsContract.kt
+++ b/app/src/main/java/com/cesar/androidtest/recentposts/RecentPostsContract.kt
@@ -12,7 +12,7 @@ interface RecentPostsContract {
 
     interface Presenter {
         fun onLoad()
-        fun requestMoreItems()
+        fun requestMoreItems(lastName: String?)
         fun onSwipeToRefresh()
         fun onRequestListResponseSuccessful(response: List<RecentPostModel>)
         fun onRequestListResponseNotSuccessful()
@@ -21,6 +21,6 @@ interface RecentPostsContract {
     }
 
     interface Model {
-        fun requestList()
+        fun requestList(lastItem: String?)
     }
 }

--- a/app/src/main/java/com/cesar/androidtest/recentposts/RecentPostsContract.kt
+++ b/app/src/main/java/com/cesar/androidtest/recentposts/RecentPostsContract.kt
@@ -12,6 +12,7 @@ interface RecentPostsContract {
 
     interface Presenter {
         fun onLoad()
+        fun requestMoreItems()
         fun onSwipeToRefresh()
         fun onRequestListResponseSuccessful(response: List<RecentPostModel>)
         fun onRequestListResponseNotSuccessful()

--- a/app/src/main/java/com/cesar/androidtest/recentposts/RecentPostsContract.kt
+++ b/app/src/main/java/com/cesar/androidtest/recentposts/RecentPostsContract.kt
@@ -5,6 +5,7 @@ import com.cesar.androidtest.recentposts.model.RecentPostModel
 interface RecentPostsContract {
     interface View {
         fun onListLoadingComplete(postsListResult: List<RecentPostModel>)
+        fun onListAddingComplete(response: List<RecentPostModel>)
         fun hideLoading()
         fun onPostsListItemClicked(listItem: android.view.View)
         fun showPostDetails()
@@ -14,13 +15,14 @@ interface RecentPostsContract {
         fun onLoad()
         fun requestMoreItems(lastName: String?)
         fun onSwipeToRefresh()
-        fun onRequestListResponseSuccessful(response: List<RecentPostModel>)
+        fun onReplaceListResponseSuccessful(response: List<RecentPostModel>)
+        fun onAddToListResponseSuccessful(response: List<RecentPostModel>)
         fun onRequestListResponseNotSuccessful()
         fun onRequestListFailure()
         fun onPostsListItemClicked()
     }
 
     interface Model {
-        fun requestList(lastItem: String?)
+        fun requestList(lastViewed: String?)
     }
 }

--- a/app/src/main/java/com/cesar/androidtest/recentposts/RecentPostsModel.kt
+++ b/app/src/main/java/com/cesar/androidtest/recentposts/RecentPostsModel.kt
@@ -8,9 +8,9 @@ class RecentPostsModel(val api: RecentPostsApi) : RecentPostsContract.Model {
 
     var presenter: RecentPostsContract.Presenter? = null
 
-    override fun requestList() {
+    override fun requestList(lastItem : String?) {
 
-        api.list(object : RecentPostsApi.ResultListener {
+        api.list(lastItem, object : RecentPostsApi.ResultListener {
             override fun onResponseSuccessful(response: List<RecentPostModel>) {
                 presenter?.onRequestListResponseSuccessful(response)
             }

--- a/app/src/main/java/com/cesar/androidtest/recentposts/RecentPostsModel.kt
+++ b/app/src/main/java/com/cesar/androidtest/recentposts/RecentPostsModel.kt
@@ -8,11 +8,15 @@ class RecentPostsModel(val api: RecentPostsApi) : RecentPostsContract.Model {
 
     var presenter: RecentPostsContract.Presenter? = null
 
-    override fun requestList(lastItem : String?) {
+    override fun requestList(lastViewed: String?) {
 
-        api.list(lastItem, object : RecentPostsApi.ResultListener {
+        api.list(lastViewed, object : RecentPostsApi.ResultListener {
             override fun onResponseSuccessful(response: List<RecentPostModel>) {
-                presenter?.onRequestListResponseSuccessful(response)
+                if (lastViewed == null) {
+                    presenter?.onReplaceListResponseSuccessful(response)
+                } else {
+                    presenter?.onAddToListResponseSuccessful(response)
+                }
             }
 
             override fun onResponseNotSuccessful() {

--- a/app/src/main/java/com/cesar/androidtest/recentposts/RecentPostsPresenter.kt
+++ b/app/src/main/java/com/cesar/androidtest/recentposts/RecentPostsPresenter.kt
@@ -8,15 +8,15 @@ class RecentPostsPresenter @Inject constructor(
         RecentPostsContract.Presenter {
 
     override fun onLoad() {
-        model.requestList()
+        model.requestList(null)
     }
 
-    override fun requestMoreItems() {
-        model.requestList()
+    override fun requestMoreItems(lastName: String?) {
+        model.requestList(lastName)
     }
 
     override fun onSwipeToRefresh() {
-        model.requestList()
+        model.requestList(null)
     }
 
     override fun onRequestListResponseSuccessful(response: List<RecentPostModel>) {

--- a/app/src/main/java/com/cesar/androidtest/recentposts/RecentPostsPresenter.kt
+++ b/app/src/main/java/com/cesar/androidtest/recentposts/RecentPostsPresenter.kt
@@ -19,9 +19,14 @@ class RecentPostsPresenter @Inject constructor(
         model.requestList(null)
     }
 
-    override fun onRequestListResponseSuccessful(response: List<RecentPostModel>) {
+    override fun onReplaceListResponseSuccessful(response: List<RecentPostModel>) {
         view.hideLoading()
         view.onListLoadingComplete(response)
+    }
+
+    override fun onAddToListResponseSuccessful(response: List<RecentPostModel>) {
+        view.hideLoading()
+        view.onListAddingComplete(response)
     }
 
     override fun onRequestListResponseNotSuccessful() {

--- a/app/src/main/java/com/cesar/androidtest/recentposts/RecentPostsPresenter.kt
+++ b/app/src/main/java/com/cesar/androidtest/recentposts/RecentPostsPresenter.kt
@@ -11,6 +11,10 @@ class RecentPostsPresenter @Inject constructor(
         model.requestList()
     }
 
+    override fun requestMoreItems() {
+        model.requestList()
+    }
+
     override fun onSwipeToRefresh() {
         model.requestList()
     }

--- a/app/src/main/java/com/cesar/androidtest/recentposts/model/RecentPostModel.kt
+++ b/app/src/main/java/com/cesar/androidtest/recentposts/model/RecentPostModel.kt
@@ -9,6 +9,8 @@ class RecentPostModel {
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 class Data {
+    var after: String? = null
+    var name: String? = null
     var children: Array<RecentPostModel>? = null
     var title: String? = null
     var url: String? = null

--- a/app/src/main/java/com/cesar/androidtest/recentposts/model/RecentPostsApi.kt
+++ b/app/src/main/java/com/cesar/androidtest/recentposts/model/RecentPostsApi.kt
@@ -1,7 +1,7 @@
 package com.cesar.androidtest.recentposts.model
 
 interface RecentPostsApi {
-    fun list(callback: ResultListener?)
+    fun list(lastViewed: String?, callback: ResultListener?)
 
     interface ResultListener {
         fun onResponseSuccessful(response: List<RecentPostModel>)

--- a/app/src/main/java/com/cesar/androidtest/recentposts/model/RecentPostsApiImpl.kt
+++ b/app/src/main/java/com/cesar/androidtest/recentposts/model/RecentPostsApiImpl.kt
@@ -8,11 +8,16 @@ class RecentPostsApiImpl(val service: RecentPostsService) : RecentPostsApi {
 
     companion object {
         val TAG = "API-RecentPosts"
+        val pageSize = 10
     }
 
-    override fun list(callback: RecentPostsApi.ResultListener?) {
+    override fun list(lastViewed: String?, callback: RecentPostsApi.ResultListener?) {
 
-        val listCall: Call<RecentPostModel>? = service.list()
+        val listCall: Call<RecentPostModel>? = service.list(
+                limit = pageSize,
+                count = pageSize,
+                after = lastViewed
+        )
 
         listCall?.enqueue(object : Callback<RecentPostModel> {
             override fun onResponse(call: Call<RecentPostModel>?, response: Response<RecentPostModel>?) {

--- a/app/src/main/java/com/cesar/androidtest/recentposts/model/RecentPostsService.kt
+++ b/app/src/main/java/com/cesar/androidtest/recentposts/model/RecentPostsService.kt
@@ -2,9 +2,14 @@ package com.cesar.androidtest.recentposts.model
 
 import retrofit2.Call
 import retrofit2.http.GET
+import retrofit2.http.Query
 
 interface RecentPostsService {
 
     @GET("r/Android/new/.json")
-    fun list(): Call<RecentPostModel>
+    fun list(
+            @Query("limit") limit: Int,
+            @Query("count") count: Int,
+            @Query("after") after: String?
+    ): Call<RecentPostModel>
 }

--- a/app/src/main/java/com/cesar/androidtest/recentposts/recyclerview/EndlessRecyclerViewScrollListener.kt
+++ b/app/src/main/java/com/cesar/androidtest/recentposts/recyclerview/EndlessRecyclerViewScrollListener.kt
@@ -1,0 +1,108 @@
+package com.cesar.androidtest.recentposts.recyclerview
+
+import android.support.v7.widget.GridLayoutManager
+import android.support.v7.widget.LinearLayoutManager
+import android.support.v7.widget.RecyclerView
+import android.support.v7.widget.StaggeredGridLayoutManager
+
+// created by nesquena
+// https://gist.github.com/nesquena/d09dc68ff07e845cc622
+
+abstract class EndlessRecyclerViewScrollListener : RecyclerView.OnScrollListener {
+
+    // The minimum amount of items to have below your current scroll position
+    // before loading more.
+    private var visibleThreshold = 5
+    // The current offset index of data you have loaded
+    private var currentPage = 0
+    // The total number of items in the dataset after the last load
+    private var previousTotalItemCount = 0
+    // True if we are still waiting for the last set of data to load.
+    private var loading = true
+    // Sets the starting page index
+    private val startingPageIndex = 0
+
+    internal var mLayoutManager: RecyclerView.LayoutManager
+
+    constructor(layoutManager: LinearLayoutManager) {
+        this.mLayoutManager = layoutManager
+    }
+
+    constructor(layoutManager: GridLayoutManager) {
+        this.mLayoutManager = layoutManager
+        visibleThreshold = visibleThreshold * layoutManager.spanCount
+    }
+
+    constructor(layoutManager: StaggeredGridLayoutManager) {
+        this.mLayoutManager = layoutManager
+        visibleThreshold = visibleThreshold * layoutManager.spanCount
+    }
+
+    fun getLastVisibleItem(lastVisibleItemPositions: IntArray): Int {
+        var maxSize = 0
+        for (i in lastVisibleItemPositions.indices) {
+            if (i == 0) {
+                maxSize = lastVisibleItemPositions[i]
+            } else if (lastVisibleItemPositions[i] > maxSize) {
+                maxSize = lastVisibleItemPositions[i]
+            }
+        }
+        return maxSize
+    }
+
+    // This happens many times a second during a scroll, so be wary of the code you place here.
+    // We are given a few useful parameters to help us work out if we need to load some more data,
+    // but first we check if we are waiting for the previous load to finish.
+    override fun onScrolled(view: RecyclerView?, dx: Int, dy: Int) {
+        var lastVisibleItemPosition = 0
+        val totalItemCount = mLayoutManager.itemCount
+
+        if (mLayoutManager is StaggeredGridLayoutManager) {
+            val lastVisibleItemPositions = (mLayoutManager as StaggeredGridLayoutManager).findLastVisibleItemPositions(null)
+            // get maximum element within the list
+            lastVisibleItemPosition = getLastVisibleItem(lastVisibleItemPositions)
+        } else if (mLayoutManager is GridLayoutManager) {
+            lastVisibleItemPosition = (mLayoutManager as GridLayoutManager).findLastVisibleItemPosition()
+        } else if (mLayoutManager is LinearLayoutManager) {
+            lastVisibleItemPosition = (mLayoutManager as LinearLayoutManager).findLastVisibleItemPosition()
+        }
+
+        // If the total item count is zero and the previous isn't, assume the
+        // list is invalidated and should be reset back to initial state
+        if (totalItemCount < previousTotalItemCount) {
+            this.currentPage = this.startingPageIndex
+            this.previousTotalItemCount = totalItemCount
+            if (totalItemCount == 0) {
+                this.loading = true
+            }
+        }
+        // If it’s still loading, we check to see if the dataset count has
+        // changed, if so we conclude it has finished loading and update the current page
+        // number and total item count.
+        if (loading && totalItemCount > previousTotalItemCount) {
+            loading = false
+            previousTotalItemCount = totalItemCount
+        }
+
+        // If it isn’t currently loading, we check to see if we have breached
+        // the visibleThreshold and need to reload more data.
+        // If we do need to reload some more data, we execute onLoadMore to fetch the data.
+        // threshold should reflect how many total columns there are too
+        if (!loading && lastVisibleItemPosition + visibleThreshold > totalItemCount) {
+            currentPage++
+            onLoadMore(currentPage, totalItemCount, view)
+            loading = true
+        }
+    }
+
+    // Call this method whenever performing new searches
+    fun resetState() {
+        this.currentPage = this.startingPageIndex
+        this.previousTotalItemCount = 0
+        this.loading = true
+    }
+
+    // Defines the process for actually loading more data based on page
+    abstract fun onLoadMore(page: Int, totalItemsCount: Int, view: RecyclerView?)
+
+}

--- a/app/src/test/java/com/cesar/androidtest/recentposts/RecentPostsActivityTest.kt
+++ b/app/src/test/java/com/cesar/androidtest/recentposts/RecentPostsActivityTest.kt
@@ -9,8 +9,8 @@ import kotlinx.android.synthetic.main.activity_recentposts.*
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.Mockito.times
-import org.mockito.Mockito.verify
+import org.mockito.ArgumentMatchers
+import org.mockito.Mockito.*
 import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
@@ -73,8 +73,8 @@ class RecentPostsActivityTest {
 
     @Test
     fun whenRequestNextDataFromApiThenPresenterRequestMoreItems() {
-        activity.loadNextDataFromApi(1)
-        verify(activity.presenter).requestMoreItems()
+        activity.loadNextDataFromApi()
+        verify(activity.presenter).requestMoreItems(null)
     }
 
 }

--- a/app/src/test/java/com/cesar/androidtest/recentposts/RecentPostsActivityTest.kt
+++ b/app/src/test/java/com/cesar/androidtest/recentposts/RecentPostsActivityTest.kt
@@ -59,7 +59,6 @@ class RecentPostsActivityTest {
     }
 
     @Test
-    @Throws(Exception::class)
     fun whenOnListItemClickedThenCallPresenter() {
         activity.onListLoadingComplete(sampleList)
 
@@ -71,4 +70,11 @@ class RecentPostsActivityTest {
 
         verify(activity.presenter).onPostsListItemClicked()
     }
+
+    @Test
+    fun whenRequestNextDataFromApiThenPresenterRequestMoreItems() {
+        activity.loadNextDataFromApi(1)
+        verify(activity.presenter).requestMoreItems()
+    }
+
 }

--- a/app/src/test/java/com/cesar/androidtest/recentposts/RecentPostsActivityTest.kt
+++ b/app/src/test/java/com/cesar/androidtest/recentposts/RecentPostsActivityTest.kt
@@ -59,8 +59,21 @@ class RecentPostsActivityTest {
     }
 
     @Test
-    fun whenOnListItemClickedThenCallPresenter() {
+    fun givenListLoadingCompleteWhenItemClickedThenCallPresenter() {
         activity.onListLoadingComplete(sampleList)
+
+        val recyclerView = activity.recyclerView
+        // workaround robolectric recyclerView issue
+        recyclerView.measure(0, 0)
+        recyclerView.layout(0, 0, 100, 1000)
+        recyclerView.findViewHolderForAdapterPosition(0).itemView.performClick()
+
+        verify(activity.presenter).onPostsListItemClicked()
+    }
+
+    @Test
+    fun givenListAddingCompleteWhenItemClickedThenCallPresenter() {
+        activity.onListAddingComplete(sampleList)
 
         val recyclerView = activity.recyclerView
         // workaround robolectric recyclerView issue

--- a/app/src/test/java/com/cesar/androidtest/recentposts/RecentPostsModelTest.kt
+++ b/app/src/test/java/com/cesar/androidtest/recentposts/RecentPostsModelTest.kt
@@ -5,7 +5,8 @@ import com.cesar.androidtest.recentposts.model.RecentPostsApi
 import org.junit.Before
 import org.junit.Test
 import org.mockito.*
-import org.mockito.Mockito.*
+import org.mockito.Mockito.same
+import org.mockito.Mockito.verify
 
 class RecentPostsModelTest {
 
@@ -22,6 +23,8 @@ class RecentPostsModelTest {
     @Captor
     private lateinit var resultListenerArgumentCaptor: ArgumentCaptor<RecentPostsApi.ResultListener>
 
+    private val lastItemSample: String = "lastItemSample"
+
     @Before
     fun setUp() {
         MockitoAnnotations.initMocks(this)
@@ -31,16 +34,16 @@ class RecentPostsModelTest {
 
     @Test
     fun whenRequestListThenCallApiList() {
-        model.requestList()
-        verify(mockApi).list(callback = any())
+        model.requestList(lastItemSample)
+        verify(mockApi).list(same(lastItemSample), callback = any())
     }
 
     @Test
     fun givenListRequestedWhenResponseSuccessfulThenCallPresenterRequestListResponseSuccessful() {
         val anyList = listOf(RecentPostModel())
-        model.requestList()
+        model.requestList(lastItemSample)
 
-        verify(mockApi).list(resultListenerArgumentCaptor.capture())
+        verify(mockApi).list(same(lastItemSample), resultListenerArgumentCaptor.capture())
         resultListenerArgumentCaptor.value.onResponseSuccessful(anyList)
 
         verify(mockPresenter).onRequestListResponseSuccessful(anyList)
@@ -48,9 +51,9 @@ class RecentPostsModelTest {
 
     @Test
     fun givenListRequestedWhenResponseNotSuccessfulThenCallPresenterRequestListResponseNotSuccessful() {
-        model.requestList()
+        model.requestList(lastItemSample)
 
-        verify(mockApi).list(resultListenerArgumentCaptor.capture())
+        verify(mockApi).list(same(lastItemSample), resultListenerArgumentCaptor.capture())
         resultListenerArgumentCaptor.value.onResponseNotSuccessful()
 
         verify(mockPresenter).onRequestListResponseNotSuccessful()
@@ -59,9 +62,9 @@ class RecentPostsModelTest {
     @Test
     fun givenListRequestedWhenFailureThenCallPresenterRequestListFailure() {
         val anyString = "Some error message"
-        model.requestList()
+        model.requestList(lastItemSample)
 
-        verify(mockApi).list(resultListenerArgumentCaptor.capture())
+        verify(mockApi).list(same(lastItemSample), resultListenerArgumentCaptor.capture())
         resultListenerArgumentCaptor.value.onFailure(anyString)
 
         verify(mockPresenter).onRequestListFailure()

--- a/app/src/test/java/com/cesar/androidtest/recentposts/RecentPostsModelTest.kt
+++ b/app/src/test/java/com/cesar/androidtest/recentposts/RecentPostsModelTest.kt
@@ -2,6 +2,7 @@ package com.cesar.androidtest.recentposts
 
 import com.cesar.androidtest.recentposts.model.RecentPostModel
 import com.cesar.androidtest.recentposts.model.RecentPostsApi
+import com.nhaarman.mockito_kotlin.isNull
 import org.junit.Before
 import org.junit.Test
 import org.mockito.*
@@ -39,14 +40,25 @@ class RecentPostsModelTest {
     }
 
     @Test
-    fun givenListRequestedWhenResponseSuccessfulThenCallPresenterRequestListResponseSuccessful() {
+    fun givenListRequestedWithLastViewedWhenResponseSuccessfulThenCallPresenterAddToListResponseSuccessful() {
         val anyList = listOf(RecentPostModel())
         model.requestList(lastItemSample)
 
         verify(mockApi).list(same(lastItemSample), resultListenerArgumentCaptor.capture())
         resultListenerArgumentCaptor.value.onResponseSuccessful(anyList)
 
-        verify(mockPresenter).onRequestListResponseSuccessful(anyList)
+        verify(mockPresenter).onAddToListResponseSuccessful(anyList)
+    }
+
+    @Test
+    fun givenListRequestedWithoutLastViewedWhenResponseSuccessfulThenCallPresenterReplaceListResponseSuccessful() {
+        val anyList = listOf(RecentPostModel())
+        model.requestList(null)
+
+        verify(mockApi).list(isNull(), resultListenerArgumentCaptor.capture())
+        resultListenerArgumentCaptor.value.onResponseSuccessful(anyList)
+
+        verify(mockPresenter).onReplaceListResponseSuccessful(anyList)
     }
 
     @Test

--- a/app/src/test/java/com/cesar/androidtest/recentposts/RecentPostsPresenterTest.kt
+++ b/app/src/test/java/com/cesar/androidtest/recentposts/RecentPostsPresenterTest.kt
@@ -4,9 +4,7 @@ import com.cesar.androidtest.recentposts.model.RecentPostModel
 import com.nhaarman.mockito_kotlin.verify
 import org.junit.Before
 import org.junit.Test
-import org.mockito.ArgumentMatchers.anyString
 import org.mockito.Mockito
-import org.mockito.Mockito.times
 
 class RecentPostsPresenterTest {
 
@@ -42,10 +40,17 @@ class RecentPostsPresenterTest {
     }
 
     @Test
-    fun givenListRequestedWhenModelReturnsSuccessThenCallViewSuccess() {
-        presenter.onRequestListResponseSuccessful(listOf(RecentPostModel()))
-        verify(mockView, times(1)).hideLoading()
-        verify(mockView, times(1)).onListLoadingComplete(any())
+    fun givenListRequestedWhenModelReturnsReplaceSuccessThenCallViewSuccess() {
+        presenter.onReplaceListResponseSuccessful(listOf(RecentPostModel()))
+        verify(mockView).hideLoading()
+        verify(mockView).onListLoadingComplete(any())
+    }
+
+    @Test
+    fun givenListRequestedWhenModelReturnsAddSuccessThenCallViewSuccess() {
+        presenter.onAddToListResponseSuccessful(listOf(RecentPostModel()))
+        verify(mockView).hideLoading()
+        verify(mockView).onListAddingComplete(any())
     }
 
     @Test

--- a/app/src/test/java/com/cesar/androidtest/recentposts/RecentPostsPresenterTest.kt
+++ b/app/src/test/java/com/cesar/androidtest/recentposts/RecentPostsPresenterTest.kt
@@ -11,6 +11,7 @@ class RecentPostsPresenterTest {
 
     // Helper function for Mockito with Kotlin
     private fun <T> any(): T {Mockito.any<T>();return uninitialized()}
+    @Suppress("UNCHECKED_CAST")
     private fun <T> uninitialized(): T = null as T
 
     lateinit var mockView: RecentPostsContract.View
@@ -50,4 +51,9 @@ class RecentPostsPresenterTest {
         verify(mockView).showPostDetails()
     }
 
+    @Test
+    fun whenRequestMoreItemsThenCallModelRequestList() {
+        presenter.requestMoreItems()
+        verify(mockModel).requestList()
+    }
 }

--- a/app/src/test/java/com/cesar/androidtest/recentposts/RecentPostsPresenterTest.kt
+++ b/app/src/test/java/com/cesar/androidtest/recentposts/RecentPostsPresenterTest.kt
@@ -4,6 +4,7 @@ import com.cesar.androidtest.recentposts.model.RecentPostModel
 import com.nhaarman.mockito_kotlin.verify
 import org.junit.Before
 import org.junit.Test
+import org.mockito.ArgumentMatchers.anyString
 import org.mockito.Mockito
 import org.mockito.Mockito.times
 
@@ -18,6 +19,8 @@ class RecentPostsPresenterTest {
     lateinit var mockModel: RecentPostsContract.Model
     lateinit var presenter: RecentPostsContract.Presenter
 
+    private val lastItemSample: String = "lastItemSample"
+
     @Before
     fun setUp() {
         mockView = Mockito.mock(RecentPostsContract.View::class.java)
@@ -29,13 +32,13 @@ class RecentPostsPresenterTest {
     @Test
     fun whenOnLoadThenRequestListToModel() {
         presenter.onLoad()
-        verify(mockModel, times(1)).requestList()
+        verify(mockModel).requestList(null)
     }
 
     @Test
     fun whenOnSwipeToRefreshThenRequestListToModel() {
         presenter.onSwipeToRefresh()
-        verify(mockModel, times(1)).requestList()
+        verify(mockModel).requestList(null)
     }
 
     @Test
@@ -53,7 +56,7 @@ class RecentPostsPresenterTest {
 
     @Test
     fun whenRequestMoreItemsThenCallModelRequestList() {
-        presenter.requestMoreItems()
-        verify(mockModel).requestList()
+        presenter.requestMoreItems(lastItemSample)
+        verify(mockModel).requestList(lastItemSample)
     }
 }

--- a/app/src/test/java/com/cesar/androidtest/recentposts/model/RecentPostsApiImplTest.kt
+++ b/app/src/test/java/com/cesar/androidtest/recentposts/model/RecentPostsApiImplTest.kt
@@ -5,8 +5,7 @@ import okhttp3.ResponseBody
 import org.junit.Before
 import org.junit.Test
 import org.mockito.*
-import org.mockito.Mockito.`when`
-import org.mockito.Mockito.verify
+import org.mockito.Mockito.*
 import retrofit2.Call
 import retrofit2.Callback
 import retrofit2.Response
@@ -23,6 +22,7 @@ class RecentPostsApiImplTest {
     private lateinit var mockListCall: Call<RecentPostModel>
     private val sampleList = arrayOf(RecentPostModel())
     private val sampleRoot = RecentPostModel()
+    private val sampleName: String = "sampleName"
     @Captor
     private lateinit var callbackArgumentCaptor: ArgumentCaptor<Callback<RecentPostModel>>
 
@@ -32,6 +32,7 @@ class RecentPostsApiImplTest {
         sampleData.author = "Sample Author"
         sampleData.title = "Sample Title"
         sampleData.url = "http://www.pudim.com.br"
+        sampleData.after = sampleName
         samplePost.data = sampleData
         sampleList[0] = samplePost
         val sampleRootData = Data()
@@ -48,8 +49,9 @@ class RecentPostsApiImplTest {
 
     @Test
     fun whenApiListThenCallServiceList() {
-        api.list(mockListener)
-        verify(mockService).list()
+        api.list(sampleName, mockListener)
+        verify(mockService).list(ArgumentMatchers.anyInt(), ArgumentMatchers.anyInt(),
+                same(sampleName))
     }
 
     @Test
@@ -57,8 +59,9 @@ class RecentPostsApiImplTest {
         val response: Response<RecentPostModel> =
                 Response.success(sampleRoot)
 
-        `when`(mockService.list()).thenReturn(mockListCall)
-        api.list(mockListener)
+        `when`(mockService.list(ArgumentMatchers.anyInt(), ArgumentMatchers.anyInt(),
+                same(sampleName))).thenReturn(mockListCall)
+        api.list(sampleName, mockListener)
         verify(mockListCall).enqueue(callbackArgumentCaptor.capture())
         callbackArgumentCaptor.value.onResponse(mockListCall, response)
 
@@ -70,8 +73,9 @@ class RecentPostsApiImplTest {
         val response: Response<RecentPostModel> =
                 Response.success(null)
 
-        `when`(mockService.list()).thenReturn(mockListCall)
-        api.list(mockListener)
+        `when`(mockService.list(ArgumentMatchers.anyInt(), ArgumentMatchers.anyInt(),
+                same(sampleName))).thenReturn(mockListCall)
+        api.list(sampleName, mockListener)
         verify(mockListCall).enqueue(callbackArgumentCaptor.capture())
         callbackArgumentCaptor.value.onResponse(mockListCall, response)
 
@@ -86,8 +90,9 @@ class RecentPostsApiImplTest {
                         "\"{\\\"sampleKey\\\":[\\\"sampleValue\\\"]}\"")
                 )
 
-        `when`(mockService.list()).thenReturn(mockListCall)
-        api.list(mockListener)
+        `when`(mockService.list(ArgumentMatchers.anyInt(), ArgumentMatchers.anyInt(),
+                same(sampleName))).thenReturn(mockListCall)
+        api.list(sampleName, mockListener)
         verify(mockListCall).enqueue(callbackArgumentCaptor.capture())
         callbackArgumentCaptor.value.onResponse(mockListCall, response)
 
@@ -97,8 +102,9 @@ class RecentPostsApiImplTest {
     @Test
     fun whenApiListFailureThenCallbackFailure() {
         val message = "Some error message"
-        `when`(mockService.list()).thenReturn(mockListCall)
-        api.list(mockListener)
+        `when`(mockService.list(ArgumentMatchers.anyInt(), ArgumentMatchers.anyInt(),
+                same(sampleName))).thenReturn(mockListCall)
+        api.list(sampleName, mockListener)
         verify(mockListCall).enqueue(callbackArgumentCaptor.capture())
         callbackArgumentCaptor.value.onFailure(mockListCall, Throwable(message))
 


### PR DESCRIPTION
This MR is related to adding endless scrolling functionality to the Recent Posts list.

Scroll down a bit and you'll see the magic happening. When it reaches a threshold, the Activity should make a new request. When it sends the right parameters, the response is added to the list instead of replacing it.

Pull-to-refresh replaces it with the first page.