### PR TITLE
Feature/add network error handling

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -62,6 +62,8 @@ dependencies {
     implementation "com.android.support:recyclerview-v7:$support_version"
     // CardView
     implementation "com.android.support:cardview-v7:$support_version"
+    // Snackbar
+    implementation "com.android.support:design:$support_version"
 
     // Tests ----------------
 

--- a/app/src/main/java/com/cesar/androidtest/recentposts/RecentPostsActivity.kt
+++ b/app/src/main/java/com/cesar/androidtest/recentposts/RecentPostsActivity.kt
@@ -102,8 +102,17 @@ open class RecentPostsActivity : AppCompatActivity(), RecentPostsContract.View,
     override fun onPostsListItemClicked(listItem: View) {
         presenter.onPostsListItemClicked()
     }
+
     override fun showPostDetails() {
         Log.v("RecentPostsActivity", "Post details requested!")
+    }
+
+    override fun onRequestListResponseNotSuccessful() {
+        //TODO
+    }
+
+    override fun onRequestListFailure() {
+        //TODO
     }
 }
 

--- a/app/src/main/java/com/cesar/androidtest/recentposts/RecentPostsActivity.kt
+++ b/app/src/main/java/com/cesar/androidtest/recentposts/RecentPostsActivity.kt
@@ -1,6 +1,7 @@
 package com.cesar.androidtest.recentposts
 
 import android.os.Bundle
+import android.support.design.widget.Snackbar
 import android.support.v4.widget.SwipeRefreshLayout
 import android.support.v7.app.AppCompatActivity
 import android.support.v7.widget.LinearLayoutManager
@@ -108,11 +109,21 @@ open class RecentPostsActivity : AppCompatActivity(), RecentPostsContract.View,
     }
 
     override fun onRequestListResponseNotSuccessful() {
-        //TODO
+        val snackbar: Snackbar = Snackbar.make(
+                recentPostsLayout, MESSAGE_REQUEST_NOT_SUCCESSFUL, Snackbar.LENGTH_SHORT)
+        snackbar.show()
     }
 
     override fun onRequestListFailure() {
-        //TODO
+        val snackbar: Snackbar = Snackbar.make(
+                recentPostsLayout, MESSAGE_REQUEST_FAILURE, Snackbar.LENGTH_SHORT)
+        snackbar.show()
+    }
+
+    companion object {
+        const val TAG = "RecentPostsActivity"
+        const val MESSAGE_REQUEST_NOT_SUCCESSFUL = "Erro ao receber posts"
+        const val MESSAGE_REQUEST_FAILURE = "Não foi possível receber posts. Verifique sua conexão"
     }
 }
 

--- a/app/src/main/java/com/cesar/androidtest/recentposts/RecentPostsActivity.kt
+++ b/app/src/main/java/com/cesar/androidtest/recentposts/RecentPostsActivity.kt
@@ -93,6 +93,7 @@ open class RecentPostsActivity : AppCompatActivity(), RecentPostsContract.View,
             adapter.notifyDataSetChanged()
         }
     }
+
     override fun onListAddingComplete(response: List<RecentPostModel>) {
         runOnUiThread {
             postsList.addAll(response)
@@ -105,25 +106,25 @@ open class RecentPostsActivity : AppCompatActivity(), RecentPostsContract.View,
     }
 
     override fun showPostDetails() {
-        Log.v("RecentPostsActivity", "Post details requested!")
+        Log.v(TAG, "Post details requested!")
     }
 
     override fun onRequestListResponseNotSuccessful() {
-        val snackbar: Snackbar = Snackbar.make(
-                recentPostsLayout, MESSAGE_REQUEST_NOT_SUCCESSFUL, Snackbar.LENGTH_SHORT)
+        val message = applicationContext.getString(
+                R.string.message_error_list_request_not_successful)
+        val snackbar: Snackbar = Snackbar.make(recentPostsLayout, message, Snackbar.LENGTH_SHORT)
         snackbar.show()
     }
 
     override fun onRequestListFailure() {
-        val snackbar: Snackbar = Snackbar.make(
-                recentPostsLayout, MESSAGE_REQUEST_FAILURE, Snackbar.LENGTH_SHORT)
+        val message = applicationContext.getString(
+                R.string.message_error_list_request_failure)
+        val snackbar: Snackbar = Snackbar.make(recentPostsLayout, message, Snackbar.LENGTH_SHORT)
         snackbar.show()
     }
 
     companion object {
         const val TAG = "RecentPostsActivity"
-        const val MESSAGE_REQUEST_NOT_SUCCESSFUL = "Erro ao receber posts"
-        const val MESSAGE_REQUEST_FAILURE = "Não foi possível receber posts. Verifique sua conexão"
     }
 }
 

--- a/app/src/main/java/com/cesar/androidtest/recentposts/RecentPostsActivity.kt
+++ b/app/src/main/java/com/cesar/androidtest/recentposts/RecentPostsActivity.kt
@@ -74,8 +74,6 @@ open class RecentPostsActivity : AppCompatActivity(), RecentPostsContract.View,
             lastName = postsList.last().data?.name
         }
         presenter.requestMoreItems(lastName)
-        // TODO: Append the new data objects to the existing set of items inside the array of items
-        // TODO: Notify the adapter of the new items made with `notifyItemRangeInserted()`
     }
 
     override fun onRefresh() {
@@ -112,14 +110,19 @@ open class RecentPostsActivity : AppCompatActivity(), RecentPostsContract.View,
     override fun onRequestListResponseNotSuccessful() {
         val message = applicationContext.getString(
                 R.string.message_error_list_request_not_successful)
-        val snackbar: Snackbar = Snackbar.make(recentPostsLayout, message, Snackbar.LENGTH_SHORT)
-        snackbar.show()
+        createSnackBar(message)
     }
 
     override fun onRequestListFailure() {
         val message = applicationContext.getString(
                 R.string.message_error_list_request_failure)
-        val snackbar: Snackbar = Snackbar.make(recentPostsLayout, message, Snackbar.LENGTH_SHORT)
+        createSnackBar(message)
+    }
+
+    private fun createSnackBar(message: String) {
+        val snackbar: Snackbar = Snackbar.make(recentPostsLayout, message,
+                Snackbar.LENGTH_INDEFINITE)
+        snackbar.setAction(R.string.retry) { loadNextDataFromApi() }
         snackbar.show()
     }
 

--- a/app/src/main/java/com/cesar/androidtest/recentposts/RecentPostsContract.kt
+++ b/app/src/main/java/com/cesar/androidtest/recentposts/RecentPostsContract.kt
@@ -9,6 +9,8 @@ interface RecentPostsContract {
         fun hideLoading()
         fun onPostsListItemClicked(listItem: android.view.View)
         fun showPostDetails()
+        fun onRequestListResponseNotSuccessful()
+        fun onRequestListFailure()
     }
 
     interface Presenter {

--- a/app/src/main/java/com/cesar/androidtest/recentposts/RecentPostsPresenter.kt
+++ b/app/src/main/java/com/cesar/androidtest/recentposts/RecentPostsPresenter.kt
@@ -30,11 +30,13 @@ class RecentPostsPresenter @Inject constructor(
     }
 
     override fun onRequestListResponseNotSuccessful() {
-        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        view.hideLoading()
+        view.onRequestListResponseNotSuccessful()
     }
 
     override fun onRequestListFailure() {
-        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        view.hideLoading()
+        view.onRequestListFailure()
     }
 
     override fun onPostsListItemClicked() {

--- a/app/src/main/java/com/cesar/androidtest/recentposts/model/RecentPostsApiImpl.kt
+++ b/app/src/main/java/com/cesar/androidtest/recentposts/model/RecentPostsApiImpl.kt
@@ -6,11 +6,6 @@ import retrofit2.Response
 
 class RecentPostsApiImpl(val service: RecentPostsService) : RecentPostsApi {
 
-    companion object {
-        val TAG = "API-RecentPosts"
-        val pageSize = 10
-    }
-
     override fun list(lastViewed: String?, callback: RecentPostsApi.ResultListener?) {
 
         val listCall: Call<RecentPostModel>? = service.list(
@@ -36,6 +31,11 @@ class RecentPostsApiImpl(val service: RecentPostsService) : RecentPostsApi {
                 callback?.onFailure(t?.message.toString())
             }
         })
+    }
+
+    companion object {
+        const val TAG = "API-RecentPosts"
+        const val pageSize = 10
     }
 
 }

--- a/app/src/main/res/layout/activity_recentposts.xml
+++ b/app/src/main/res/layout/activity_recentposts.xml
@@ -7,6 +7,7 @@
     <android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
         xmlns:app="http://schemas.android.com/apk/res-auto"
         xmlns:tools="http://schemas.android.com/tools"
+        android:id="@+id/recentPostsLayout"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         tools:context="com.cesar.androidtest.recentposts.RecentPostsActivity">

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -3,4 +3,5 @@
     <string name="recent_posts_thumbnail_description">This post\'s thumbnail</string>
     <string name="message_error_list_request_not_successful">Erro ao receber posts</string>
     <string name="message_error_list_request_failure">Não foi possível receber posts. Verifique sua conexão</string>
+    <string name="retry">Tentar de novo</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,4 +1,6 @@
 <resources>
     <string name="app_name">Android Test</string>
     <string name="recent_posts_thumbnail_description">This post\'s thumbnail</string>
+    <string name="message_error_list_request_not_successful">Erro ao receber posts</string>
+    <string name="message_error_list_request_failure">Não foi possível receber posts. Verifique sua conexão</string>
 </resources>

--- a/app/src/test/java/com/cesar/androidtest/recentposts/RecentPostsPresenterTest.kt
+++ b/app/src/test/java/com/cesar/androidtest/recentposts/RecentPostsPresenterTest.kt
@@ -64,4 +64,18 @@ class RecentPostsPresenterTest {
         presenter.requestMoreItems(lastItemSample)
         verify(mockModel).requestList(lastItemSample)
     }
+
+    @Test
+    fun whenOnRequestListResponseNotSuccessfulThenCallViewOnRequestListResponseNotSuccessful() {
+        presenter.onRequestListResponseNotSuccessful()
+        verify(mockView).hideLoading()
+        verify(mockView).onRequestListResponseNotSuccessful()
+    }
+    
+    @Test
+    fun whenOnRequestListFailureThenCallViewOnRequestListFailure() {
+        presenter.onRequestListFailure()
+        verify(mockView).hideLoading()
+        verify(mockView).onRequestListFailure()
+    }
 }


### PR DESCRIPTION
This MR is for adding network error/fail handling.
The app should show a SnackBar when it happens. It's up to the user retrying the posts retrieval.
![image](https://user-images.githubusercontent.com/782204/38179301-f7c00b0c-35f7-11e8-9f5f-968224bd4ad9.png)